### PR TITLE
Add hypershift and nerc-ocp cluster overlays

### DIFF
--- a/overlays/hypershift1/kustomization.yaml
+++ b/overlays/hypershift1/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  nerc.mghpcc.org/kustomized: "true"
+
+resources:
+- ../../base

--- a/overlays/hypershift2/kustomization.yaml
+++ b/overlays/hypershift2/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  nerc.mghpcc.org/kustomized: "true"
+
+resources:
+- ../../base

--- a/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/overlays/nerc-ocp-obs/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  nerc.mghpcc.org/kustomized: "true"
+
+resources:
+- ../../base

--- a/overlays/nerc-ocp-test/kustomization.yaml
+++ b/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  nerc.mghpcc.org/kustomized: "true"
+
+resources:
+- ../../base


### PR DESCRIPTION
This adds overlays for hypershift1, hypershift2, nerc-ocp-obs, nerc-ocp-test clusters